### PR TITLE
Linguistic refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 
 ### Pre-requests
 
-* Your server's network type should be Full-cone NAT.
-    > If you don't known what it means, just do it to test.
+* Your server's network type should be [Full-cone NAT](https://en.wikipedia.org/wiki/Network_address_translation#Methods_of_translation).
+  > If you don't known what it means, no worries, just continue.
 
 * If your server is behind a firewall or a household router, you probably need to enable [UPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play) or do a [port forwarding](https://en.wikipedia.org/wiki/Port_forwarding) to your server on your router since they may block all incoming traffics.
 
@@ -36,7 +36,7 @@
 
 Please check [mnh_server](https://github.com/hzyitc/mnh_server).
 
-> Only `mnhv1` is currently supported, more protocols will be added in the future, such as [STUN](https://en.wikipedia.org/wiki/STUN).
+> Only `mnhv1` protocol is currently supported, more protocols will be added in the future, such as [STUN](https://en.wikipedia.org/wiki/STUN).
 
 ### Run mnh
 
@@ -52,25 +52,28 @@ Flags:
   -p, --port int         The local hole port which incoming traffics access to
   -t, --service string   Target service address. Only need in proxy mode (default "127.0.0.1:80")
 
-  -u, --disupnp          Disable UPnP
+  -u, --disable-upnp     Disable UPnP
 
   -h, --help             help for mnh
 ```
 
-Running a quick test with UPnP helping: 
+Example:
 
 ```
 ./mnh --server server.com:12345 --id test
 ```
 
-Expose access to a local web server with UPnP helping:
+Expose a local web server:
 
 ```
 ./mnh --server server.com:12345 --id web --mode proxy --service 127.0.0.1:80
 ```
 
-Expose access to a local web server without UPnP helping (You probably need to do a port forwarding on your router):
+`mnh` will attempt to request UPnP port forwarding by default.
+
+You can disable it by adding `--disable-upnp`, make sure you have set up port forwarding correctly.
+(See [Pre-requests](#pre-requests))
 
 ```
-./mnh --server server.com:12345 --id web --mode proxy --service 127.0.0.1:80 --port 8888 --disupnp
+./mnh --server server.com:12345 --id web --mode proxy --service 127.0.0.1:80 --port 8888 --disable-upnp
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -29,7 +29,7 @@
 ### 要求
 
 1. 你的网络必须是Full-cone型NAT。
-    > 如果你不知道这句话是什么意思，尽管试试这个程序。
+   > 如果你不知道这句话是什么意思，尽管试试这个程序。
 
 2. 如果你的服务在防火墙或者家用路由后面，那么你需要在路由上开启[UPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play)或者设置[端口转发](https://en.wikipedia.org/wiki/Port_forwarding)，因为大部分家用路由会阻止入站连接。
 
@@ -53,12 +53,12 @@ Flags:
   -p, --port int         本地洞端口，入口流量将会访问这个端口
   -t, --service string   目标服务地址. 仅proxy模式需要 (默认为 "127.0.0.1:80")
 
-  -u, --disupnp          禁用UPnP
+  -u, --disable-upnp          禁用UPnP
 
   -h, --help             输出本帮助
 ```
 
-使用UPnP协助运行一次快速测试: 
+使用UPnP协助运行一次快速测试:
 
 ```
 ./mnh --server server.com:12345 --id test
@@ -73,5 +73,5 @@ Flags:
 不使用UPnP协助暴露本地Web服务器（你可能需要再路由上设置端口转发）:
 
 ```
-./mnh --server server.com:12345 --id web --mode proxy --service 127.0.0.1:80 --port 8888 --disupnp
+./mnh --server server.com:12345 --id web --mode proxy --service 127.0.0.1:80 --port 8888 --disable-upnp
 ```

--- a/main.go
+++ b/main.go
@@ -16,10 +16,9 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "mnh",
-	Short: "A tool thats help to punch nat hole so that peer can directly connect to your NATed server without client.",
-	Long: `mnh is a tool that makes exposing a port behind NAT possible.
-mnh client will produce an ip:port pair for your NATed server which can be used for public access.`,
-
+	Short: "A NAT hole punching tool that allows peers directly connect to your NATed server without client.",
+	Long: "mnh is a tool that makes exposing a port behind NAT possible.\n" +
+		"mnh client will produce an ip:port pair for your NATed server which can be used for public access.",
 	Run: func(cmd *cobra.Command, args []string) {
 		trueMain()
 	},
@@ -45,7 +44,7 @@ func cmdRegister(cmd *cobra.Command) {
 	cmd.PersistentFlags().IntVarP(&port, "port", "p", 0, "The local hole port which incoming traffics access to")
 	cmd.PersistentFlags().StringVarP(&service, "service", "t", "127.0.0.1:80", "Target service address. Only need in proxy mode")
 
-	cmd.PersistentFlags().BoolVarP(&upnpD, "disupnp", "u", false, "Disable UPnP")
+	cmd.PersistentFlags().BoolVarP(&upnpD, "disable-upnp", "u", false, "Disable UPnP")
 }
 
 func main() {

--- a/routerPortForward/upnp.go
+++ b/routerPortForward/upnp.go
@@ -1,6 +1,9 @@
 package routerPortForward
 
-import "gitlab.com/NebulousLabs/go-upnp"
+import (
+	"github.com/hzyitc/mnh/log"
+	"gitlab.com/NebulousLabs/go-upnp"
+)
 
 type Config struct {
 	Enable bool
@@ -21,26 +24,31 @@ func New(config Config, port int) (Interface, error) {
 	p := uint16(port)
 
 	if !config.Enable {
+		goto NO_UPNP
+	} else {
+		log.Info("Attempting UPnP port forward, this might take a while...")
+		log.Info("You can disable this behavior by adding --disable-upnp")
+		d, err := upnp.Discover()
+		if err != nil {
+			// Do not quit if upnp fails, fix #1
+			log.Info("UPnP port forward failed.")
+			log.Info("Falling back to non UPnP mode, you might need to do a port forward manually on your router.")
+			goto NO_UPNP
+		}
+
+		d.Forward(p, "mnh")
 		return &upnpImpl{
 			config,
 			p,
-
-			nil,
+			d,
 		}, nil
 	}
 
-	d, err := upnp.Discover()
-	if err != nil {
-		return nil, err
-	}
-
-	d.Forward(p, "mnh")
-
+NO_UPNP:
 	return &upnpImpl{
 		config,
 		p,
-
-		d,
+		nil,
 	}, nil
 }
 

--- a/routerPortForward/upnp.go
+++ b/routerPortForward/upnp.go
@@ -1,9 +1,6 @@
 package routerPortForward
 
-import (
-	"github.com/hzyitc/mnh/log"
-	"gitlab.com/NebulousLabs/go-upnp"
-)
+import "gitlab.com/NebulousLabs/go-upnp"
 
 type Config struct {
 	Enable bool
@@ -24,31 +21,26 @@ func New(config Config, port int) (Interface, error) {
 	p := uint16(port)
 
 	if !config.Enable {
-		goto NO_UPNP
-	} else {
-		log.Info("Attempting UPnP port forward, this might take a while...")
-		log.Info("You can disable this behavior by adding --disable-upnp")
-		d, err := upnp.Discover()
-		if err != nil {
-			// Do not quit if upnp fails, fix #1
-			log.Info("UPnP port forward failed.")
-			log.Info("Falling back to non UPnP mode, you might need to do a port forward manually on your router.")
-			goto NO_UPNP
-		}
-
-		d.Forward(p, "mnh")
 		return &upnpImpl{
 			config,
 			p,
-			d,
+
+			nil,
 		}, nil
 	}
 
-NO_UPNP:
+	d, err := upnp.Discover()
+	if err != nil {
+		return nil, err
+	}
+
+	d.Forward(p, "mnh")
+
 	return &upnpImpl{
 		config,
 		p,
-		nil,
+
+		d,
 	}, nil
 }
 


### PR DESCRIPTION
This patch contains some minor linguistic refinements.

Please note that command line option `disupnp` has been changed to `disable-upnp`.
