### PR TITLE
Continue if UPnP fails, fix #2

### DIFF
--- a/routerPortForward/upnp.go
+++ b/routerPortForward/upnp.go
@@ -1,6 +1,9 @@
 package routerPortForward
 
-import "gitlab.com/NebulousLabs/go-upnp"
+import (
+	"github.com/hzyitc/mnh/log"
+	"gitlab.com/NebulousLabs/go-upnp"
+)
 
 type Config struct {
 	Enable bool
@@ -21,26 +24,31 @@ func New(config Config, port int) (Interface, error) {
 	p := uint16(port)
 
 	if !config.Enable {
+		goto NO_UPNP
+	} else {
+		log.Info("Attempting UPnP port forward, this might take a while...")
+		log.Info("You can disable this behavior by adding --disable-upnp")
+		d, err := upnp.Discover()
+		if err != nil {
+			// Do not quit if upnp fails, fix #1
+			log.Info("UPnP port forward failed.")
+			log.Info("Falling back to non UPnP mode, you might need to do a port forward manually on your router.")
+			goto NO_UPNP
+		}
+
+		d.Forward(p, "mnh")
 		return &upnpImpl{
 			config,
 			p,
-
-			nil,
+			d,
 		}, nil
 	}
 
-	d, err := upnp.Discover()
-	if err != nil {
-		return nil, err
-	}
-
-	d.Forward(p, "mnh")
-
+NO_UPNP:
 	return &upnpImpl{
 		config,
 		p,
-
-		d,
+		nil,
 	}, nil
 }
 


### PR DESCRIPTION
This patch fixed issue https://github.com/hzyitc/mnh/issues/2

UPnP is enabled by default, however, UPnP implementation is not available on all routers/firewalls.

This patch allows program to continue without UPnP and prints warning message.